### PR TITLE
Bump supported Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
This should have been done in PR #52
Note this means that aioca release 1.8 incorrectly claims Python3.7 support, when in actuality it does not work.