### PR TITLE
Update copier template to 2.4.0

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2.3.0
+_commit: 2.4.0
 _src_path: gh:DiamondLightSource/python-copier-template
 author_email: tom.cobb@diamond.ac.uk
 author_name: Tom Cobb

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,4 +24,4 @@ It is recommended that developers use a [vscode devcontainer](https://code.visua
 
 This project was created using the [Diamond Light Source Copier Template](https://github.com/DiamondLightSource/python-copier-template) for Python projects.
 
-For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/2.3.0/how-to.html).
+For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/2.4.0/how-to.html).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
 ARG PYTHON_VERSION=3.11
-FROM python:${PYTHON_VERSION} as developer
+FROM python:${PYTHON_VERSION} AS developer
 
 # Add any system dependencies for the developer/build environment here
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/DiamondLightSource/aioca/actions/workflows/ci.yml/badge.svg)](https://github.com/DiamondLightSource/aioca/actions/workflows/ci.yml)
 [![Coverage](https://codecov.io/gh/DiamondLightSource/aioca/branch/main/graph/badge.svg)](https://codecov.io/gh/DiamondLightSource/aioca)
 [![PyPI](https://img.shields.io/pypi/v/aioca.svg)](https://pypi.org/project/aioca)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 # aioca
 


### PR DESCRIPTION
This is done to fix the link check fails caused by the License URL