### PR TITLE
chore: Update supported Python versions through copier template update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 2.5.0
+_commit: 3.0.0
 _src_path: gh:DiamondLightSource/python-copier-template
 author_email: tom.cobb@diamond.ac.uk
 author_name: Tom Cobb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,11 +28,11 @@
         }
     },
     "features": {
-        // Some default things like git config
-        "ghcr.io/devcontainers/features/common-utils:2": {
-            "upgradePackages": false
-        }
+        // add in eternal history and other bash features
+        "ghcr.io/diamondlightsource/devcontainer-features/bash-config:1": {}
     },
+    // Create the config folder for the bash-config feature
+    "initializeCommand": "mkdir -p ${localEnv:HOME}/.config/bash-config",
     "runArgs": [
         // Allow the container to access the host X11 display and EPICS CA
         "--net=host",

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -24,4 +24,4 @@ It is recommended that developers use a [vscode devcontainer](https://code.visua
 
 This project was created using the [Diamond Light Source Copier Template](https://github.com/DiamondLightSource/python-copier-template) for Python projects.
 
-For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/2.5.0/how-to.html).
+For more information on common tasks like setting up a developer environment, running the tests, and setting a pre-commit hook, see the template's [How-to guides](https://diamondlightsource.github.io/python-copier-template/3.0.0/how-to.html).

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ assignees: ''
 
 ---
 
-Describe the bug, including a clear and concise description of the expected behavior, the actual behavior and the context in which you encountered it (ideally include details of your environment).
+Describe the bug, including a clear and concise description of the expected behaviour, the actual behavior and the context in which you encountered it (ideally include details of your environment).
 
 ## Steps To Reproduce
 Steps to reproduce the behavior:

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Create GitHub Release
         # We pin to the SHA, not the tag, for security reasons.
         # https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
-        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
         with:
           prerelease: ${{ contains(github.ref_name, 'a') || contains(github.ref_name, 'b') || contains(github.ref_name, 'rc') }}
           files: "*"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -54,7 +54,7 @@ jobs:
         run: tox -e tests
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           name: ${{ inputs.python-version }}/${{ inputs.runs-on }}
           files: cov.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         runs-on: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
         include:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,10 @@ jobs:
           # Include one that runs in the dev environment
           - runs-on: "ubuntu-latest"
             python-version: "dev"
+        exclude:
+          # See issue #63
+          - runs-on: "macos-latest"
+            python-version: "3.13"
       fail-fast: false
     uses: ./.github/workflows/_test.yml
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
         name: Run black
         stages: [pre-commit]
         language: system
-        entry: black --check --diff
+        entry: ruff check --force-exclude --fix
         types: [python]
 
       - id: ruff

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,17 +1,15 @@
 Changelog
 =========
 
-All notable changes to this project will be documented in this file.
+
+**ATTENTION:** This file is deprecated in favour of `Github Releases <https://github.com/DiamondLightSource/aioca/releases>`_
+
+The file is retained for historical reference only but will no longer be updated.
+
 
 The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
 and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
 
-Unreleased_
------------
-
-Fixed:
-
-- `Bump supported Python versions and update copier template <../../pull/59>`
 
 1.8.1_ - 2024-11-01
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,9 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Unreleased_
 -----------
 
-Nothing yet
+Fixed:
+
+- `Bump supported Python versions and update copier template <../../pull/59>`
 
 1.8.1_ - 2024-11-01
 -----------

--- a/docs/tutorials/installation.md
+++ b/docs/tutorials/installation.md
@@ -2,7 +2,7 @@
 
 ## Check your version of python
 
-You will need python 3.10 or later. You can check your version of python by
+You will need python 3.11 or later. You can check your version of python by
 typing into a terminal:
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 description = "Asynchronous Channel Access client for asyncio and Python using libca via ctypes"
 dependencies = [
     "numpy",
-    "epicscorelibs >= 7.0.3.99.4.0",
+    "epicscorelibs >= 7.0.7.99.1.2a3",
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"
@@ -30,7 +30,7 @@ dev = [
     "pipdeptree",
     "pre-commit",
     "pydata-sphinx-theme>=0.12",
-    "pytest<8",  # See issue #62 
+    "pytest<8",                  # See issue #62
     "pytest-asyncio",
     "pytest-cov",
     "ruff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,9 @@ name = "aioca"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 description = "Asynchronous Channel Access client for asyncio and Python using libca via ctypes"
 dependencies = [
@@ -20,7 +19,7 @@ dependencies = [
 dynamic = ["version"]
 license.file = "LICENSE"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 
 [project.optional-dependencies]
 dev = [

--- a/src/aioca/_catools.py
+++ b/src/aioca/_catools.py
@@ -1,6 +1,5 @@
 import asyncio
 import atexit
-import collections
 import ctypes
 import functools
 import inspect
@@ -9,6 +8,7 @@ import threading
 import time
 import traceback
 import warnings
+from collections import deque
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, Generic, TypeVar, overload
 
@@ -264,9 +264,7 @@ class ChannelCache:
         self.__channels: dict[str, Channel] = {}
         self.__loop = loop
         self.__waiting = True
-        self.__callbacks: collections.deque[tuple[Callable, tuple]] = (
-            collections.deque()
-        )
+        self.__callbacks: deque[tuple[Callable, tuple]] = deque()
 
     def get_channel(self, name: str) -> Channel:
         try:
@@ -343,7 +341,7 @@ class Subscription:
     def __init__(
         self,
         name: str,
-        callback: Callable[[Any], None | Awaitable],
+        callback: Callable[[Any], Awaitable | None],
         events: Dbe,
         datatype: Datatype,
         format: Format,
@@ -360,7 +358,7 @@ class Subscription:
         #: while another callback was in progress
         self.dropped_callbacks: int = 0
         self.__event_loop = asyncio.get_running_loop()
-        self.pending_values: collections.deque[AugmentedValue] = collections.deque(
+        self.pending_values: deque[AugmentedValue] = deque(
             maxlen=None if all_updates else 1
         )
         self.__future: asyncio.Future | None = None
@@ -553,7 +551,7 @@ class Subscription:
 @overload
 def camonitor(
     pv: str,
-    callback: Callable[[Any], None | Awaitable],
+    callback: Callable[[Any], Awaitable | None],
     events: Dbe = ...,
     datatype: Datatype = ...,
     format: Format = ...,
@@ -567,7 +565,7 @@ def camonitor(
 @overload
 def camonitor(
     pv: PVs,
-    callback: Callable[[Any, int], None | Awaitable],
+    callback: Callable[[Any, int], Awaitable | None],
     events: Dbe = ...,
     datatype: Datatype = ...,
     format: Format = ...,

--- a/src/aioca/_catools.py
+++ b/src/aioca/_catools.py
@@ -9,29 +9,15 @@ import threading
 import time
 import traceback
 import warnings
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Deque,
-    Dict,
-    Generic,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Tuple,
-    TypeVar,
-    Union,
-    overload,
-)
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any, Generic, TypeVar, overload
 
 from epicscorelibs.ca import cadef, dbr
 
 from .types import AugmentedValue, Count, Datatype, Dbe, Format, Timeout
 
 T = TypeVar("T")
-PVs = Union[List[str], Tuple[str, ...]]
+PVs = list[str] | tuple[str, ...]
 
 DEFAULT_TIMEOUT = 5.0
 
@@ -48,10 +34,10 @@ cadef.ca_detach_context = cadef.libca.ca_detach_context
 
 class ValueEvent(Generic[T]):
     def __init__(self) -> None:
-        self.value: Union[T, Exception] = RuntimeError("No value set")
+        self.value: T | Exception = RuntimeError("No value set")
         self._event = asyncio.Event()
 
-    def set(self, value: Union[T, Exception]):
+    def set(self, value: T | Exception):
         self._event.set()
         self.value = value
 
@@ -153,14 +139,14 @@ async def ca_timeout(awaitable: Awaitable[T], name: str, timeout: Timeout = None
             timeout = timeout[0] - time.time()
         try:
             result = await asyncio.wait_for(awaitable, timeout)
-        except asyncio.TimeoutError as e:
+        except TimeoutError as e:
             raise CANothing(name, cadef.ECA_TIMEOUT) from e
     else:
         result = await awaitable
     return result
 
 
-def parallel_timeout(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+def parallel_timeout(kwargs: dict[str, Any]) -> dict[str, Any]:
     """Return kwargs with a suitable timeout for running in parallel"""
     if kwargs.get("throw", True):
         # told to throw, so remove the timeout as it will be done at the top level
@@ -169,8 +155,8 @@ def parallel_timeout(kwargs: Dict[str, Any]) -> Dict[str, Any]:
 
 
 async def in_parallel(
-    awaitables: Sequence[Awaitable[T]], kwargs: Dict[str, Any]
-) -> List[T]:
+    awaitables: Sequence[Awaitable[T]], kwargs: dict[str, Any]
+) -> list[T]:
     if kwargs.get("throw", True):
         # timeout at this level, awaitables will not timeout themselves
         timeout = kwargs.get("timeout", DEFAULT_TIMEOUT)
@@ -224,7 +210,7 @@ class Channel:
     def __init__(self, name: str, loop: asyncio.AbstractEventLoop):
         """Creates a channel access channel with the given name."""
         self.name = name
-        self.__subscriptions: Set[Subscription] = set()
+        self.__subscriptions: set[Subscription] = set()
         self.__connect_event = ValueEvent[None]()
         self.__event_loop = loop
 
@@ -275,10 +261,12 @@ class ChannelCache:
     ensure a clean shutdown."""
 
     def __init__(self, loop: asyncio.AbstractEventLoop):
-        self.__channels: Dict[str, Channel] = {}
+        self.__channels: dict[str, Channel] = {}
         self.__loop = loop
         self.__waiting = True
-        self.__callbacks: Deque[Tuple[Callable, Tuple]] = collections.deque()
+        self.__callbacks: collections.deque[tuple[Callable, tuple]] = (
+            collections.deque()
+        )
 
     def get_channel(self, name: str) -> Channel:
         try:
@@ -290,7 +278,7 @@ class ChannelCache:
             self.__channels[name] = channel
             return channel
 
-    def get_channels(self) -> List[Channel]:
+    def get_channels(self) -> list[Channel]:
         return list(self.__channels.values())
 
     def purge(self):
@@ -355,7 +343,7 @@ class Subscription:
     def __init__(
         self,
         name: str,
-        callback: Callable[[Any], Union[None, Awaitable]],
+        callback: Callable[[Any], None | Awaitable],
         events: Dbe,
         datatype: Datatype,
         format: Format,
@@ -372,12 +360,12 @@ class Subscription:
         #: while another callback was in progress
         self.dropped_callbacks: int = 0
         self.__event_loop = asyncio.get_running_loop()
-        self.pending_values: Deque[AugmentedValue] = collections.deque(
+        self.pending_values: collections.deque[AugmentedValue] = collections.deque(
             maxlen=None if all_updates else 1
         )
-        self.__future: Optional[asyncio.Future] = None
+        self.__future: asyncio.Future | None = None
         self.__lock = threading.Lock()  # Used for update merging.
-        self.__is_async: Optional[bool] = None
+        self.__is_async: bool | None = None
 
         # If events not specified then compute appropriate default corresponding
         # to the requested format.
@@ -407,9 +395,9 @@ class Subscription:
         self: Subscription = args.usr
 
         try:
-            assert (
-                args.status == cadef.ECA_NORMAL
-            ), f"Subscription {self.name} got bad status {args.status}"
+            assert args.status == cadef.ECA_NORMAL, (
+                f"Subscription {self.name} got bad status {args.status}"
+            )
             # Good data: extract value from the dbr. Note that this can fail
             value = self.dbr_to_value(args.raw_dbr, args.type, args.count)
             self.__queue_value(value)
@@ -565,7 +553,7 @@ class Subscription:
 @overload
 def camonitor(
     pv: str,
-    callback: Callable[[Any], Union[None, Awaitable]],
+    callback: Callable[[Any], None | Awaitable],
     events: Dbe = ...,
     datatype: Datatype = ...,
     format: Format = ...,
@@ -579,7 +567,7 @@ def camonitor(
 @overload
 def camonitor(
     pv: PVs,
-    callback: Callable[[Any, int], Union[None, Awaitable]],
+    callback: Callable[[Any, int], None | Awaitable],
     events: Dbe = ...,
     datatype: Datatype = ...,
     format: Format = ...,
@@ -587,7 +575,7 @@ def camonitor(
     all_updates: bool = ...,
     notify_disconnect: bool = ...,
     connect_timeout: Timeout = ...,
-) -> List[Subscription]: ...  # pragma: no cover
+) -> list[Subscription]: ...  # pragma: no cover
 
 
 def camonitor(
@@ -684,7 +672,7 @@ async def caget(
     count: Count = ...,
     timeout: Timeout = ...,
     throw: bool = ...,
-) -> List[AugmentedValue]: ...  # pragma: no cover
+) -> list[AugmentedValue]: ...  # pragma: no cover
 
 
 @maybe_throw
@@ -788,7 +776,7 @@ async def caput(
     wait: bool = ...,
     timeout: Timeout = ...,
     throw: bool = ...,
-) -> List[CANothing]: ...  # pragma: no cover
+) -> list[CANothing]: ...  # pragma: no cover
 
 
 @maybe_throw
@@ -864,7 +852,8 @@ async def caput_array(pvs: PVs, values, repeat_value=False, **kwargs):
             values = [values] * len(pvs)
     assert len(pvs) == len(values), "PV and value lists must match in length"
     coros = [
-        caput(pv, value, **parallel_timeout(kwargs)) for pv, value in zip(pvs, values)
+        caput(pv, value, **parallel_timeout(kwargs))
+        for pv, value in zip(pvs, values, strict=False)
     ]
     results = await in_parallel(coros, kwargs)
     return results
@@ -934,7 +923,7 @@ async def connect(
 @overload
 async def connect(
     pv: PVs, wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
-) -> List[CANothing]: ...  # pragma: no cover
+) -> list[CANothing]: ...  # pragma: no cover
 
 
 @maybe_throw
@@ -980,7 +969,7 @@ async def cainfo(
 @overload
 async def cainfo(
     pv: PVs, wait: bool = ..., timeout: Timeout = ..., throw: bool = ...
-) -> List[CAInfo]: ...  # pragma: no cover
+) -> list[CAInfo]: ...  # pragma: no cover
 
 
 @maybe_throw
@@ -1010,7 +999,7 @@ async def cainfo_array(pvs: PVs, wait=True, **kwargs):
 class _Context:
     _ca_context = None
     _should_destroy = False
-    _channel_caches: Dict[asyncio.AbstractEventLoop, ChannelCache] = {}
+    _channel_caches: dict[asyncio.AbstractEventLoop, ChannelCache] = {}
 
     @classmethod
     def purge_channel_caches(cls):
@@ -1114,7 +1103,7 @@ class ChannelInfo:
         self.subscriber_count = subscriber_count
 
 
-def get_channel_infos() -> List[ChannelInfo]:
+def get_channel_infos() -> list[ChannelInfo]:
     """Return information about all Channels"""
     return [
         ChannelInfo(channel.name, channel.connected(), channel.count_subscriptions())

--- a/src/aioca/types.py
+++ b/src/aioca/types.py
@@ -1,5 +1,6 @@
 from datetime import datetime  # noqa
-from typing import List, Literal, Protocol, Sized, Tuple, Type, Union
+from typing import Literal, Protocol
+from collections.abc import Sized
 
 #: A timeout is represented by one of the following
 #:
@@ -9,7 +10,7 @@ from typing import List, Literal, Protocol, Sized, Tuple, Type, Union
 #: float    A relative timeout interval in seconds
 #: (float,) An absolute deadline in seconds past epoch
 #: ======== ============================================================
-Timeout = Union[None, Tuple[float], float]
+Timeout = float | tuple[float] | None
 
 #: A bitwise or of DBE event codes from epicscorelibs.ca.dbr
 #:
@@ -34,7 +35,7 @@ Timeout = Union[None, Tuple[float], float]
 #: FORMAT_TIME  DBE_VALUE | DBE_ALARM
 #: FORMAT_CTRL  DBE_VALUE | DBE_ALARM | DBE_PROPERTY
 #: ============ =============================================
-Dbe = Union[None, int]
+Dbe = int | None
 
 #: A DBR request code from epicscorelibs.ca.dbr. One of
 #:
@@ -67,7 +68,7 @@ Dbr = Literal[0, 1, 2, 3, 4, 5, 6, 35, 36, 37, 38, 996, 997, 998, 999]
 #:                      such as int, float or str
 #: A numpy dtype        Compatible with any of the above values
 #: ==================== ================================================
-Datatype = Union[None, Dbr, Type]
+Datatype = None | Dbr | type
 
 #: How much auxilliary information will be returned with the retrieved data.
 #: From epicscorelibs.ca.dbr, one of the following
@@ -88,7 +89,7 @@ Format = Literal[0, 1, 2]
 #: -1       The full data length
 #: +ve int  A maximum of this number of elements
 #: ======== ============================================================
-Count = Union[Literal[0, -1], int]
+Count = Literal[0, -1] | int
 
 
 class AugmentedValue(Protocol, Sized):
@@ -152,7 +153,7 @@ class AugmentedValue(Protocol, Sized):
     #: epoch, not the EPICS epoch).  Is a tuple of the form ``(secs, nsec)`` with
     #: integer seconds and nanosecond values, provided in case full ns timestamp
     #: precision is required.
-    raw_stamp: Tuple[int, int]
+    raw_stamp: tuple[int, int]
     #: Timestamp in seconds in format compatible with ``time.time()`` rounded to
     #: the nearest microsecond: for nanosecond precision use `raw_stamp`
     #: instead.
@@ -170,7 +171,7 @@ class AugmentedValue(Protocol, Sized):
     upper_ctrl_limit: float  #: Upper limit for puts to this value
     lower_ctrl_limit: float  #: Lower limit for puts to this value
     precision: int  #: Display precision for floating point values
-    enums: List[str]  #: Enumeration strings for ENUM type
+    enums: list[str]  #: Enumeration strings for ENUM type
     #: Used for global alarm acknowledgement. Do transient alarms have
     #: to be acknowledged? (0,1) means (no, yes).
     ackt: int

--- a/src/aioca/types.py
+++ b/src/aioca/types.py
@@ -68,7 +68,7 @@ Dbr = Literal[0, 1, 2, 3, 4, 5, 6, 35, 36, 37, 38, 996, 997, 998, 999]
 #:                      such as int, float or str
 #: A numpy dtype        Compatible with any of the above values
 #: ==================== ================================================
-Datatype = None | Dbr | type
+Datatype = Dbr | type | None
 
 #: How much auxilliary information will be returned with the retrieved data.
 #: From epicscorelibs.ca.dbr, one of the following

--- a/tests/test_aioca.py
+++ b/tests/test_aioca.py
@@ -8,8 +8,8 @@ import sys
 import threading
 import time
 from asyncio.events import AbstractEventLoop
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, List, Tuple, Union
 
 import pytest
 from _pytest.unraisableexception import catch_unraisable_exception
@@ -155,7 +155,7 @@ async def test_get_non_existent_pvs_no_throw(ioc: subprocess.Popen) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pvs", ([LONGOUT, SI], (LONGOUT, SI)))
 async def test_get_two_pvs(
-    ioc: subprocess.Popen, pvs: Union[List[str], Tuple[str]]
+    ioc: subprocess.Popen, pvs: list[str] | tuple[str]
 ) -> None:
     value = await caget(pvs, timeout=TIMEOUT)
     assert [42, "me"] == value
@@ -200,7 +200,7 @@ async def test_caput_on_ro_pv_fails(ioc: subprocess.Popen) -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pvs", ([LONGOUT, SI], (LONGOUT, SI)))
 async def test_caput_two_pvs_same_value(
-    ioc: subprocess.Popen, pvs: Union[List[str], Tuple[str]]
+    ioc: subprocess.Popen, pvs: list[str] | tuple[str]
 ) -> None:
     await caput(pvs, 43, timeout=TIMEOUT)
     value = await caget(pvs)
@@ -255,7 +255,7 @@ async def poll_length(array, gt=0, timeout=TIMEOUT):
 
 @pytest.mark.asyncio
 async def test_monitor(ioc: subprocess.Popen) -> None:
-    values: List[AugmentedValue] = []
+    values: list[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -276,7 +276,7 @@ async def test_monitor(ioc: subprocess.Popen) -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_with_failing_dbr(ioc: subprocess.Popen, capsys) -> None:
-    values: List[AugmentedValue] = []
+    values: list[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -310,7 +310,7 @@ async def test_monitor_with_failing_dbr(ioc: subprocess.Popen, capsys) -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_two_pvs(ioc: subprocess.Popen) -> None:
-    values: List[Tuple[AugmentedValue, int]] = []
+    values: list[tuple[AugmentedValue, int]] = []
     await caput(WAVEFORM, [1, 2], wait=True, timeout=TIMEOUT)
     ms = camonitor([WAVEFORM, LONGOUT], lambda v, n: values.append((v, n)), count=-1)
 
@@ -428,7 +428,7 @@ async def test_exception_raising_monitor_callback(
     assert "ValueError: list.remove(x): x not in list" in captured.err
 
     # Check no more updates
-    values: List[str] = []
+    values: list[str] = []
     m.callback = values.append
     await caput(LONGOUT, 32)
     assert m.state == m.CLOSED
@@ -462,7 +462,7 @@ async def test_async_exception_raising_monitor_callback(
     assert "ValueError: Boom" in captured.err
 
     # Check no more updates
-    values: List[str] = []
+    values: list[str] = []
     m.callback = values.append
     await caput(LONGOUT, 32)
     assert m.state == m.CLOSED
@@ -474,7 +474,7 @@ async def test_async_exception_raising_monitor_callback(
 
 @pytest.mark.asyncio
 async def test_camonitor_non_existent() -> None:
-    values: List[AugmentedValue] = []
+    values: list[AugmentedValue] = []
     m = camonitor(NE, values.append, connect_timeout=0.2)
     try:
         assert len(values) == 0
@@ -504,7 +504,7 @@ async def test_camonitor_non_existent_async() -> None:
 
 @pytest.mark.asyncio
 async def test_monitor_gc(ioc: subprocess.Popen) -> None:
-    values: List[AugmentedValue] = []
+    values: list[AugmentedValue] = []
     camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection
@@ -648,7 +648,7 @@ async def test_read_pvs_from_different_threads(ioc: subprocess.Popen) -> None:
 
 @pytest.mark.asyncio
 async def test_channel_connected(ioc: subprocess.Popen) -> None:
-    values: List[AugmentedValue] = []
+    values: list[AugmentedValue] = []
     m = camonitor(LONGOUT, values.append, notify_disconnect=True)
 
     # Wait for connection


### PR DESCRIPTION
Adds support for Python 3.13 and drops for Python <=3.10 following the [Numpy deprecation policy](https://numpy.org/neps/nep-0029-deprecation_policy.html), and keeps dependencies, CI and infrastructure up to date with Diamond standards.

### Instructions to reviewer on how to test:
1. Ensure that CI passes on all versions to remain supported

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes
