### PR TITLE
Convert to use asyncio.get_running_loop

### DIFF
--- a/src/aioca/_catools.py
+++ b/src/aioca/_catools.py
@@ -371,7 +371,7 @@ class Subscription:
         #: The number of updates that have been dropped as they happened
         #: while another callback was in progress
         self.dropped_callbacks: int = 0
-        self.__event_loop = asyncio.get_event_loop()
+        self.__event_loop = asyncio.get_running_loop()
         self.pending_values: Deque[AugmentedValue] = collections.deque(
             maxlen=None if all_updates else 1
         )
@@ -723,7 +723,7 @@ async def caget(pv: str, datatype=None, format=dbr.FORMAT_RAW, count=0):
     # callback routine gets to see it.
     dbrcode, dbr_to_value = dbr.type_to_dbr(channel, datatype, format)
     done = ValueEvent[AugmentedValue]()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     context = (pv, dbr_to_value, done, loop)
     ctypes.pythonapi.Py_IncRef(context)
 
@@ -823,7 +823,7 @@ async def caput(pv: str, value, datatype=None, wait=False):
         # Assemble the callback context and give it an extra reference count
         # to keep it alive until the callback handler sees it.
         done = ValueEvent[None]()
-        context = (pv, done, asyncio.get_event_loop())
+        context = (pv, done, asyncio.get_running_loop())
         ctypes.pythonapi.Py_IncRef(context)
 
         # caput with callback requested: need to wait for response from
@@ -1084,7 +1084,7 @@ class _Context:
 
     @classmethod
     def get_channel_cache(cls):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         try:
             channel_cache = cls._channel_caches[loop]
         except KeyError:
@@ -1150,6 +1150,8 @@ def run(coro, forever=False):
         forever: If True then run the event loop forever, otherwise
             return on completion of the coro
     """
+    msg = "aioca.run is deprecated, please use asyncio.run instead"
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
     loop = asyncio.get_event_loop()
     t = None
     try:

--- a/tests/test_aioca.py
+++ b/tests/test_aioca.py
@@ -603,7 +603,7 @@ def test_run_forever(event_loop: AbstractEventLoop):
     async def run_for_a_bit():
         while True:
             await asyncio.sleep(0.2)
-            asyncio.get_event_loop().stop()
+            asyncio.get_running_loop().stop()
 
     start = time.time()
     run(run_for_a_bit(), forever=True)


### PR DESCRIPTION
Also deprecate aioca.run so we don't need to change it

Fixes #60
